### PR TITLE
expose generic script runner (runScript)

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -3,6 +3,7 @@ objects = require('./objects')
 
 module.exports =
   runExcelSheet: require('./lib/runner').runExcelSheet
+  runScript: require('./lib/runner').runScript
   objects: objects
   element: objects.element
   keywords: require('./keywords')


### PR DESCRIPTION
This change exposes the generic script runner (runScript) so this can be easily reused by different script runners (such as google spreadsheet)